### PR TITLE
Support multi-value WrappedValues

### DIFF
--- a/parser/src/rules/given/mod.rs
+++ b/parser/src/rules/given/mod.rs
@@ -829,7 +829,7 @@ do: count >= 3"#;
 		let data = r#"{where: {gereqs: 'MCD | MCG'}, given: courses, what: courses, do: count > 1}"#;
 
 		let expected: filter::Clause = btreemap! {
-			"gereqs".into() => filter::WrappedValue::Or([
+			"gereqs".into() => filter::WrappedValue::Or(vec![
 				filter::TaggedValue {
 					op: action::Operator::EqualTo,
 					value: filter::Value::String("MCD".into()),

--- a/tests/snapshot.sh
+++ b/tests/snapshot.sh
@@ -23,8 +23,10 @@ for catalog in $(find . -maxdepth 1 -type d -name '*-*' | sed 's|^./||' | grep -
 
 		for area in $(find . -maxdepth 1 -name '*.yaml' | sed 's|^./||' | sed 's|\.yaml||' | grep -v '^.$'); do
 			echo "current: $kind, $area"
-			cargo run --quiet --bin degreepath-printer-cli "./$area.yaml" > "$SNAPSHOT_DIR/$area.md"
-			cargo run --quiet --bin degreepath-parser-cli "./$area.yaml" > "$SNAPSHOT_DIR/$area.json"
+			cargo run --quiet --bin degreepath-printer-cli "./$area.yaml" > "$SNAPSHOT_DIR/$area.md.out"
+			mv "$SNAPSHOT_DIR/$area.md.out" "$SNAPSHOT_DIR/$area.md"
+			cargo run --quiet --bin degreepath-parser-cli "./$area.yaml" > "$SNAPSHOT_DIR/$area.json.out"
+			mv "$SNAPSHOT_DIR/$area.json.out" "$SNAPSHOT_DIR/$area.json"
 		done
 
 		cd ..

--- a/tests/snapshots/2015-16/degree/bachelor-of-music.json
+++ b/tests/snapshots/2015-16/degree/bachelor-of-music.json
@@ -695,12 +695,26 @@
                 "limit": null,
                 "where": {
                   "gereqs": {
-                    "Single": {
-                      "op": "EqualTo",
-                      "value": {
-                        "String": "AQR | SED | IST"
+                    "Or": [
+                      {
+                        "op": "EqualTo",
+                        "value": {
+                          "String": "AQR"
+                        }
+                      },
+                      {
+                        "op": "EqualTo",
+                        "value": {
+                          "String": "SED"
+                        }
+                      },
+                      {
+                        "op": "EqualTo",
+                        "value": {
+                          "String": "IST"
+                        }
                       }
-                    }
+                    ]
                   }
                 },
                 "what": "courses",

--- a/tests/snapshots/2015-16/degree/bachelor-of-music.json
+++ b/tests/snapshots/2015-16/degree/bachelor-of-music.json
@@ -558,22 +558,28 @@
             "count": "all",
             "of": [
               {
-                "course": "First-Year Writing"
+                "requirement": "First-Year Writing",
+                "optional": false
               },
               {
-                "course": "Writing in Context"
+                "requirement": "Writing in Context",
+                "optional": false
               },
               {
-                "course": "Foreign Language"
+                "requirement": "Foreign Language",
+                "optional": false
               },
               {
-                "course": "Oral Communication"
+                "requirement": "Oral Communication",
+                "optional": false
               },
               {
-                "course": "Abstract and Quantitative Reasoning"
+                "requirement": "Reasoning",
+                "optional": false
               },
               {
-                "course": "Studies in Physical Movement"
+                "requirement": "Studies in Physical Movement",
+                "optional": false
               }
             ]
           },

--- a/tests/snapshots/2015-16/degree/bachelor-of-music.md
+++ b/tests/snapshots/2015-16/degree/bachelor-of-music.md
@@ -50,14 +50,42 @@ For this requirement, you must declare at least one major.
 For this section, you must complete “Foundation”, “Core”, and “Integrative”.
 
 ## Foundation
-For this section, you must take all of the following courses:
+For this section, you must complete all of the following requirements:
 
-- First-Year Writing
-- Writing in Context
-- Foreign Language
-- Oral Communication
-- Abstract and Quantitative Reasoning
-- Studies in Physical Movement
+- “First-Year Writing”
+- “Writing in Context”
+- “Foreign Language”
+- “Oral Communication”
+- “Reasoning”
+- “Studies in Physical Movement”
+
+### First-Year Writing
+For this requirement, you must take at least one course with the “FYW” general education attribute.
+
+### Writing in Context
+For this requirement, you must take at least four courses with the “WRI” general education attribute.
+
+### Foreign Language
+For this requirement, you must take one of the following courses:
+
+- CHIN 112
+- FREN 112
+- GERM 112
+- GREEK 112
+- JAPAN 112
+- LATIN 112
+- NORW 112
+- RUSSL 112
+- SPAN 112
+
+### Oral Communication
+For this requirement, you must take at least one course with the “ORC” general education attribute.
+
+### Reasoning
+For this requirement, you must take at least one course with the AQR, SED, or IST general education attribute.
+
+### Studies in Physical Movement
+For this requirement, you must take at least two distinct courses with the “SPM” general education attribute.
 
 ## Core
 For this section, you must complete all of the following requirements:

--- a/tests/snapshots/2015-16/major/political-science.json
+++ b/tests/snapshots/2015-16/major/political-science.json
@@ -160,12 +160,44 @@
             "limit": null,
             "where": {
               "department": {
-                "Single": {
-                  "op": "EqualTo",
-                  "value": {
-                    "String": "CHIN | GREEK | LATIN | JAPAN | NORW | RUSSN"
+                "Or": [
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "CHIN"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "GREEK"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "LATIN"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "JAPAN"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "NORW"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "RUSSN"
+                    }
                   }
-                }
+                ]
               },
               "number": {
                 "Single": {
@@ -199,12 +231,26 @@
             "limit": null,
             "where": {
               "department": {
-                "Single": {
-                  "op": "EqualTo",
-                  "value": {
-                    "String": "FREN | GERM | SPAN"
+                "Or": [
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "FREN"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "GERM"
+                    }
+                  },
+                  {
+                    "op": "EqualTo",
+                    "value": {
+                      "String": "SPAN"
+                    }
                   }
-                }
+                ]
               },
               "number": {
                 "Single": {

--- a/tests/snapshots/2015-16/major/political-science.md
+++ b/tests/snapshots/2015-16/major/political-science.md
@@ -81,10 +81,10 @@ For this section, you must complete one requirement from among “Statistics”,
 For this requirement, you must take at least one course within the STAT department.
 
 ## French, German, Spanish
-For this requirement, you must take at least one course within the FREN | GERM | SPAN department and with the “>= 232” `number` attribute.
+For this requirement, you must take at least one course within the FREN, GERM, or SPAN department and with the “>= 232” `number` attribute.
 
 ## Chinese, Greek, Latin, Japanese, Norwegian, Russian
-For this requirement, you must take at least one course within the CHIN | GREEK | LATIN | JAPAN | NORW | RUSSN department and with the “>= 231” `number` attribute.
+For this requirement, you must take at least one course within the CHIN, GREEK, LATIN, JAPAN, NORW, or RUSSN department and with the “>= 231” `number` attribute.
 
 
 # Research Methods
@@ -158,10 +158,10 @@ For this section, you must complete one requirement from among “Statistics”,
 For this requirement, you must take at least one course within the STAT department.
 
 ## French, German, Spanish
-For this requirement, you must take at least one course within the FREN | GERM | SPAN department and with the “>= 232” `number` attribute.
+For this requirement, you must take at least one course within the FREN, GERM, or SPAN department and with the “>= 232” `number` attribute.
 
 ## Chinese, Greek, Latin, Japanese, Norwegian, Russian
-For this requirement, you must take at least one course within the CHIN | GREEK | LATIN | JAPAN | NORW | RUSSN department and with the “>= 231” `number` attribute.
+For this requirement, you must take at least one course within the CHIN, GREEK, LATIN, JAPAN, NORW, or RUSSN department and with the “>= 231” `number` attribute.
 
 
 # Research Methods
@@ -235,9 +235,9 @@ For this section, you must complete one requirement from among “Statistics”,
 For this requirement, you must take at least one course within the STAT department.
 
 ## French, German, Spanish
-For this requirement, you must take at least one course within the FREN | GERM | SPAN department and with the “>= 232” `number` attribute.
+For this requirement, you must take at least one course within the FREN, GERM, or SPAN department and with the “>= 232” `number` attribute.
 
 ## Chinese, Greek, Latin, Japanese, Norwegian, Russian
-For this requirement, you must take at least one course within the CHIN | GREEK | LATIN | JAPAN | NORW | RUSSN department and with the “>= 231” `number` attribute.
+For this requirement, you must take at least one course within the CHIN, GREEK, LATIN, JAPAN, NORW, or RUSSN department and with the “>= 231” `number` attribute.
 
 


### PR DESCRIPTION
Before, we only supported e.g. `where: {department: MATH | CSCI}`; now, you can have as many ORs as you would like (e.g., `where: {department: FREN | SPAN | GERM | CHIN | JAPAN | NORW}`).

This was needed for part of the PoliSci major.

I also fixed an issue in the BM definition, where I had forgotten to list some requirements as requirements.